### PR TITLE
fix: prevent XPath injection in codelist_options by using parameteriz…

### DIFF
--- a/ckanext/iso19115/tests/test_utils.py
+++ b/ckanext/iso19115/tests/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+from ckanext.iso19115.utils import codelist_options
+
+def test_codelist_options_injection():
+    """
+    Test that malicious XPath input does not manipulate the query structure.
+    """
+    # A malicious name that would have worked with f-string interpolation:
+    # f"//cat:codelistItem/cat:CT_Codelist[@id='{name}']/..."
+    # Injection: "' or 1=1 or '" would result in:
+    # //cat:codelistItem/cat:CT_Codelist[@id='' or 1=1 or '']/...
+    # which would return values from ALL codelists.
+    
+    malicious_name = "' or 1=1 or '"
+    
+    # With safe parameter binding, this should be treated as a literal string
+    # and return no results (unless a codelist literally has that ID).
+    results = codelist_options(malicious_name)
+    assert results == []
+
+def test_codelist_options_valid():
+    """
+    Test that a valid codelist name still returns expected results.
+    """
+    valid_name = "CI_RoleCode"
+    results = codelist_options(valid_name)
+    
+    # We expect some results for a valid codelist
+    assert len(results) > 0
+    # Check that it contains expected structure
+    assert hasattr(results[0], 'name')
+    assert hasattr(results[0], 'definition')
+
+def test_codelist_names():
+    """
+    Test that codelist_names returns a list of valid codelist IDs.
+    """
+    from ckanext.iso19115.utils import codelist_names
+    names = codelist_names()
+    assert len(names) > 0
+    assert "CI_RoleCode" in names

--- a/ckanext/iso19115/utils.py
+++ b/ckanext/iso19115/utils.py
@@ -212,9 +212,10 @@ def codelist_names() -> Container[str]:
 @functools.lru_cache()
 def codelist_options(name: str) -> list[CodeListValue]:
     xml = ltree.XML(_codelists.open("rb").read())
-    xpath = f"//cat:codelistItem/cat:CT_Codelist[@id='{name}']/cat:codeEntry/cat:CT_CodelistValue"
+    # Use variable substitution to prevent XPath injection
+    xpath = "//cat:codelistItem/cat:CT_Codelist[@id=$name]/cat:codeEntry/cat:CT_CodelistValue"
     namespaces = {"cat": xml.nsmap["cat"], "gco": xml.nsmap["gco"]}
-    codes = xml.xpath(xpath, namespaces=namespaces)
+    codes = xml.xpath(xpath, namespaces=namespaces, name=name)
 
     return [
         CodeListValue(


### PR DESCRIPTION
- Security: Replaced unsafe f-string interpolation with lxml variable substitution ($name) in the codelist_options XPath query. This ensures that the input is treated as a literal value, preventing attackers from manipulating the query structure.
- Testing: Added a new unit test suite in ckanext/iso19115/tests/test_utils.py to verify the fix against injection payloads and ensure valid codelist lookups continue to function as expected.